### PR TITLE
chore: Upgrade .NET 6 to .NET 7

### DIFF
--- a/DotnetFoundation/DotnetFoundation.API/DotnetFoundation.API.csproj
+++ b/DotnetFoundation/DotnetFoundation.API/DotnetFoundation.API.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.22" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.11">
       <PrivateAssets>all</PrivateAssets>

--- a/DotnetFoundation/DotnetFoundation.DAL/DotnetFoundation.DAL.csproj
+++ b/DotnetFoundation/DotnetFoundation.DAL/DotnetFoundation.DAL.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Upgrade .Net 6 to .Net 7
- Upgrade the TargetFramework
- Upgrade the used Nuget packages
- No build error found tested the configured get api working fine 

![image](https://github.com/OsmosysSoftware/dotnet-foundation/assets/121787291/f5f5c2a4-8f76-491c-a53a-c594cf1489ab)
